### PR TITLE
Feat/accounts/withdraw

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -346,6 +346,10 @@ class SocialCallbackView(APIView):
             user.set_unusable_password()
             user.save()
 
+        if user:
+            user.is_active = True
+            user.save()
+
         return user
 
     def create_jwt_token(self, user_data):

--- a/front/accounts/accounts.js
+++ b/front/accounts/accounts.js
@@ -34,6 +34,7 @@ const tokenManager = {
         } catch (error) {
             console.error('토큰 갱신 실패:', error.response ? error.response.data : error.message);
             this.clearTokens(); // 실패 시 토큰 제거
+            localStorage.clear()
             throw error;
         }
     }
@@ -72,8 +73,9 @@ axios.interceptors.response.use(
                 return axios(originalRequest); // 원래 요청 다시 시도
             } catch (err) {
                 console.error('새로운 토큰으로 재요청 실패:', err);
-                console.log("로컬 스토리지를 삭제합니다.")
+                console.log("세션 스토리지를 삭제합니다.")
                 sessionStorage.clear()
+                localStorage.clear()
 
                 alert("토큰이 만료되었습니다. 다시 로그인해주세요.")
                 window.location.href = "signin.html"


### PR DESCRIPTION
소셜 계정 회원탈퇴 오류

소셜 계정의 경우 별도의 인증 없어 회원가입 및 로그인을 합니다
기존 로직에서 회원탈퇴 시도시에 비활성화 계정으로 전환되지만,
다시 로그인 시도 시에 인증 없이 로그인이 되어 계정이 활성화 되지 않아 해당 코드를 추가하였습니다